### PR TITLE
feat: use /usr/bin/env in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PYTHON = env PYTHONPATH=${PYTHONPATH} ${VENV}/bin/python
 PIP = ${VENV}/bin/pip
 
 DEFAULT_PYTHON := /usr/bin/python3
-VIRTUALENV := /usr/bin/virtualenv
+VIRTUALENV := /usr/bin/env virtualenv
 REQUIREMENTS := -r requirements.txt
 
 default: check-coding-style


### PR DESCRIPTION
This PR switches `/usr/bin/virtualenv` for `/usr/bin/env virtualenv` which reads the user's $PATH